### PR TITLE
Use Function.name in getFunctionName()

### DIFF
--- a/src/appstate.js
+++ b/src/appstate.js
@@ -537,6 +537,10 @@ function checkArgs (args, name, promise) {
  * @returns {String}
  */
 function getFunctionName (fn) {
+  if (fn.name) {
+    return fn.name;
+  }
+
   var name = fn.toString();
   name = name.substr('function '.length);
   name = name.substr(0, name.indexOf('('));


### PR DESCRIPTION
Sometime we want to redeclare function name

```
let foo = function toBeRenamed () {};

Object.defineProperty(foo, 'name', {
  configurable: true,
  enumerable: false,
  writable: false,
  value: 'bar'
});

foo.name; // bar - success

...
// in appstate
getFunctionName(foo); // toBeRenamed - fail
```
